### PR TITLE
Modification of upcoming tasks in Daily Note Template

### DIFF
--- a/notes/Templates/Daily Note.md
+++ b/notes/Templates/Daily Note.md
@@ -57,11 +57,12 @@ cssclasses:
 
 > [!multi-column]
 >
->> [!todo] Due Next Week
+>> [!todo] Upcoming
 >> ```dataview
 >> TASK
 >> WHERE (due) AND !completed AND due > date(this.file.name) AND (due <= date(this.file.name) + dur(7 day))
->> GROUP BY header
+>> GROUP BY join(list(due, header), " - ")
+>> SORT due ASC
 >> ```
 >
 >> [!success] Done Today


### PR DESCRIPTION
The following modifications are applied :
- The title "Due next week" is modified for "Upcoming"
- The upcoming tasks for the next 7 days are grouped by (due date, header)

Below is an example in a daily note
![example_upcoming_tasks](https://github.com/user-attachments/assets/5da6f1c5-346e-4589-96c6-25b5c84ddb18)
